### PR TITLE
Always copy authorized_keys from user's if it exists

### DIFF
--- a/create.sh
+++ b/create.sh
@@ -42,14 +42,15 @@ mkdir "$TOP/tmp"
 # file available.
 #
 mkdir -p "$TOP/input/cpio"
-if [[ ! -f "$TOP/input/cpio/authorized_keys" ]]; then
-	if [[ ! -f $HOME/.ssh/authorized_keys ]]; then
+if [[ ! -f $HOME/.ssh/authorized_keys ]]; then
+	if [[ ! -f "$TOP/input/cpio/authorized_keys" ]]; then
 		echo "you have no $HOME/.ssh/authorized_keys file"
 		echo
 		echo "populate $TOP/input/cpio/authorized_keys and run again"
 		echo
 		exit 1
 	fi
+else
 	cp "$HOME/.ssh/authorized_keys" "$TOP/input/cpio/authorized_keys"
 fi
 

--- a/macos/create.sh
+++ b/macos/create.sh
@@ -69,14 +69,15 @@ mkdir "$TOP/tmp"
 # file available.
 #
 mkdir -p "$TOP/input/cpio"
-if [[ ! -f "$TOP/input/cpio/authorized_keys" ]]; then
-	if [[ ! -f $HOME/.ssh/authorized_keys ]]; then
+if [[ ! -f $HOME/.ssh/authorized_keys ]]; then
+	if [[ ! -f "$TOP/input/cpio/authorized_keys" ]]; then
 		echo "you have no $HOME/.ssh/authorized_keys file"
 		echo
 		echo "populate $TOP/input/cpio/authorized_keys and run again"
 		echo
 		exit 1
 	fi
+else
 	cp "$HOME/.ssh/authorized_keys" "$TOP/input/cpio/authorized_keys"
 fi
 


### PR DESCRIPTION
Also switched if logic to allow people who don't have an
authorized_keys file to still maintain one in input

Signed-off-by: Gan Shun Lim <ganshun@gmail.com>