### PR TITLE
create.sh: Locate qemu by using "command -v" instead of hard-coding

### DIFF
--- a/create.sh
+++ b/create.sh
@@ -153,7 +153,7 @@ cat > "$TOP/tmp/$VM.xml" <<EOF
     <suspend-to-disk enabled="no"/>
   </pm>
   <devices>
-    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <emulator>`command -v qemu-system-x86_64`</emulator>
     <disk type="file" device="disk">
       <driver name="qemu" type="qcow2"/>
       <source file="/var/lib/libvirt/images/$VM.qcow2"/>


### PR DESCRIPTION
… /usr/bin .

Right now, `create.sh` hardcodes `/usr/bin/qemu-system-x86_64`--which does not work for me.

This pull request changes it to `command -v qemu-system-x86_64` which should always work.
