### PR TITLE
Add support for creating a bridge device for use by VMs for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,34 @@ host ~ $ sudo usermod -a -G libvirt $(whoami)
 host ~ $ newgrp libvirt
 ```
 
+##### Bridged Network on Ubuntu 22.04
+
+NOTE: This only works for wired interfaces.
+
+In some cases, it's useful to bridge a VM to your local network. This allows accessing the VM
+on your the same LAN as your Linux host. The following script adds a bridge, `virbr1`, to your host
+ethernet interface. It sets it up for DHCP v4, which allows the VM to receive an IP address from
+your local router. The script then creates a bridged network named `host-bridge` for use by libvirt.
+
+First, find the name of your ethernet interface with `ip a` or `ifconfig`.
+
+Then run the script. In this example, the ethernet interface is named `enp4s0`.
+
+```
+ sudo ./create-host-bridge.sh enp4s0
+```
+
+Lastly, apply the network interface changes to the host. 
+
+**IMPORTANT**: This will cause you to lose your connection temporarily if you are SSH'd into the box.
+
+```
+sudo netplan apply
+```
+
+
+This bridge can be used by VMs by changing their configuration to use `NETWORK=host-bridge`.
+
 #### Macintosh
 
 Install VMware Fusion.  These instructions have been tested with VMware Fusion
@@ -75,6 +103,7 @@ are stored in `config/defaults.sh`:
 host ~/helios-engvm $ cat config/defaults.sh
 VM=helios
 POOL=default
+NETWORK=default
 INPUT_IMAGE=helios-qemu-ttya-full.raw
 SIZE=30G
 VCPU=2
@@ -87,6 +116,9 @@ You can override them by making a new file under `config`; e.g.,
 host ~/helios-engvm $ echo 'VCPU=8' >config/big.sh
 host ~/helios-engvm $ echo 'MEM=$(( 8 * 1024 * 1024 ))' >>config/big.sh
 ```
+
+Note: If you created a host bridge for an ubuntu system, you can use that bridge by setting
+`NETWORK=host-bridge` in the configuration similar to the examples above.
 
 You can now create a virtual machine.  If you provide an argument, it is
 the name of one of the override configuration files you have created within

--- a/config/defaults.sh
+++ b/config/defaults.sh
@@ -1,5 +1,6 @@
 VM=helios
 POOL=default
+NETWORK=default
 INPUT_IMAGE=helios-qemu-ttya-full.raw
 SIZE=30G
 VCPU=2

--- a/create.sh
+++ b/create.sh
@@ -165,7 +165,7 @@ cat > "$TOP/tmp/$VM.xml" <<EOF
       <target dev="vdb" bus="virtio"/>
     </disk>
     <interface type="network">
-      <source network="default"/>
+      <source network="$NETWORK"/>
       <model type="virtio"/>
     </interface>
     <serial type="pty"/>

--- a/ubuntu/create-host-bridge.sh
+++ b/ubuntu/create-host-bridge.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -o xtrace
+set -o pipefail
+set -o errexit
+
+if [[ -z $1 ]]; then
+    echo "Argument for ethernet interface required"
+    echo "example: $0 eth0"
+    exit 1
+fi
+
+IFACE="$1"
+
+# Backup the old netplan if it exists
+OLD_CFG="/etc/netplan/00-installer-config.yaml"
+if [[ -f "$OLD_CFG" ]]; then
+    mv $OLD_CFG $OLD_CFG.bak
+fi
+
+# Install the new netplan
+NEW_CFG="/etc/netplan/00-helios-engvm.yaml"
+cat >"$NEW_CFG" <<EOF
+network:
+  ethernets:
+    $IFACE:
+      dhcp4: false
+  version: 2
+  bridges:
+      virbr1:
+          dhcp4: yes
+          interfaces:
+              - $IFACE
+          parameters:
+              stp: true
+EOF
+
+# Setup a bridge device so VMs can reach the LAN
+virsh net-define host-bridge.xml
+virsh net-start host-bridge
+virsh net-autostart host-bridge
+

--- a/ubuntu/host-bridge.xml
+++ b/ubuntu/host-bridge.xml
@@ -1,0 +1,5 @@
+<network>
+  <name>host-bridge</name>
+  <forward mode="bridge"/>
+  <bridge name="virbr1"/>
+</network>


### PR DESCRIPTION
This change is Ubuntu specific because it uses [netplan](https://netplan.io/).
It can be made generic for Linux through the use of the [ip command](https://wiki.archlinux.org/title/Network_bridge#With_iproute2),
but this configuration will not be persistent.

The `create-host-bridge` script is also not currently idempotent, and it may
be dangerous to run on Linux boxes with more advanced networking setups besides the default.

The main purpose behind this PR is to allow setting up a single Helios VM that can be used
to run falcon and spin up other helios machines for testing.