### PR TITLE
Always pull latest artifacts for dependencies

### DIFF
--- a/image/netstack-bits.sh
+++ b/image/netstack-bits.sh
@@ -1,18 +1,73 @@
 #!/bin/bash
+#
+# This script can be ran locally or in CI for collecting the artifacts needed
+# to build a netstack image
+
+if [[ ! -f ~/.netrc ]]; then
+    echo "You must setup a .netrc file with an api.github.com machine entry"
+    echo "with a GitHub access token in order to access all needed artifacts"
+    exit 1
+fi
+
+function get_current_branch {
+    BRANCH=$(curl -n -sSf "https://api.github.com/repos/$REPO" |
+        jq -r .default_branch)
+    SHA=$(curl -n -sSf "https://api.github.com/repos/$REPO/branches/$BRANCH" |
+        jq -r .commit.sha)
+
+    echo "commit $SHA is the head of branch $BRANCH from $REPO"
+}
+
+function fetch_and_verify {
+    sha256sum --status -c "$1.sha256"
+    if [ $? -eq 0 ]; then
+        echo "latest $1 present"
+    else
+        echo "latest $1 is not present, or it is corrupted"
+        echo "fetching latest $1"
+        curl -OL $PACKAGE_URL
+        sha256sum --status -c "$1.sha256"
+    fi
+
+    # abort script if we can't successfully retrieve package
+    if [ $? -ne 0 ]; then
+        echo "could not fetch $1"
+        exit $?
+    fi
+}
 
 pushd /opt
 
-echo "fetching xde onu p5p"
-curl -OL https://buildomat.eng.oxide.computer/wg/0/artefact/01G410KK2053S6ZXH3R5M7W5GC/SEf36Yj1L7oebc8EbbrL8kIqaieAz4u2blrO40NRPsA7bN9w/01G410KWEXSFANK2YSWEGQ7GXX/01G41BVM0WH4CTCR35ZRRB5NN5/repo.p5p
-mv repo.p5p xde.p5p
+ARTIFACT_URL="https://buildomat.eng.oxide.computer/public/file"
 
-echo "fetching maghemite p5p"
-curl -OL https://buildomat.eng.oxide.computer/wg/0/artefact/01G0JAFMZ0VGR9PV1E3H4RB3PR/HOj4QkPA7jBtWP4MtbXf4d7E4mVKKX7Mp9B4R60iU4gqqbE8/01G0JAFX0CVQ97DRA0DEW48D62/01G0JB0YN94HH4GKAAQPRERWMY/maghemite-0.1.110.p5p
-mv maghemite-0.1.110.p5p mg.p5p
+banner xde
+REPO='oxidecomputer/os-build'
+get_current_branch
+PACKAGE_BASE_URL="$ARTIFACT_URL/$REPO/xde/$SHA"
+PACKAGE_URL="$PACKAGE_BASE_URL/repo.p5p"
+PACKAGE_SHA_URL="$PACKAGE_BASE_URL/repo.p5p.sha256"
+curl -L $PACKAGE_SHA_URL | sed 's/\/work\///' > repo.p5p.sha256
+fetch_and_verify repo.p5p
+# cp instead of mv to prevent re-fetching due to missing file
+cp repo.p5p xde.p5p
 
-echo "fetching opte p5p"
-curl -OL https://buildomat.eng.oxide.computer/wg/0/artefact/01G0DM53XR4E008D6ET5T8DXP6/wBWo0Jsg1AG19toIyAY23xAWhzmuNKmAsF6tL18ypZODNuHK/01G0DM5DMFN9292PRSGF0EBATG/01G0DMGDKHGEJMKPKZPWV06MCZ/opte-0.1.56.p5p
-mv opte-0.1.56.p5p opte.p5p
+banner maghemite
+REPO='oxidecomputer/maghemite'
+get_current_branch
+PACKAGE_BASE_URL="$ARTIFACT_URL/$REPO/repo/$SHA"
+PACKAGE_URL="$PACKAGE_BASE_URL/mg.p5p"
+PACKAGE_SHA_URL="$PACKAGE_BASE_URL/mg.p5p.sha256"
+curl -L $PACKAGE_SHA_URL | sed 's/\/out\///' > mg.p5p.sha256
+fetch_and_verify mg.p5p
+
+banner opte
+REPO='oxidecomputer/opte'
+get_current_branch
+PACKAGE_BASE_URL="$ARTIFACT_URL/$REPO/repo/$SHA"
+PACKAGE_URL="$PACKAGE_BASE_URL/opte.p5p"
+PACKAGE_SHA_URL="$PACKAGE_BASE_URL/opte.p5p.sha256"
+curl -L $PACKAGE_SHA_URL | sed 's/\/out\///' > opte.p5p.sha256
+fetch_and_verify opte.p5p
 
 popd
 
@@ -24,4 +79,3 @@ cp /opt/opte.p5p .
 # get the p9kp binary from oxidecomputer/p9fs ci
 echo "fetching p9kp"
 curl -OL https://buildomat.eng.oxide.computer/wg/0/artefact/01FWVH16QWB4FCKHNDADG2F8ZN/FmPrmgdSkn44eowjPWFoqikXynga4oJYhHcoBAwjB8E531tv/01FWVH1E7GXY0TRVZYGT7GJ789/01FWVHADFJEW082REBMJMJDC5R/p9kp
-


### PR DESCRIPTION
* Fetch latest git hash for `main` branch of each dependency
* Fetch sha256 of latest artifact for each dependency
* If latest artifact is not present, or if sha256 doesn't match,
  fetch latest artifact.