### PR TITLE
images: add flag to specify opte version for netdev ramdisk image

### DIFF
--- a/image/strap.sh
+++ b/image/strap.sh
@@ -26,12 +26,13 @@ COFFEE=no
 STRAP_ARGS=()
 IMAGE_SUFFIX=
 OPTE=no
+OPTE_VER=latest
 OMICRON1=no
 SSH=no
 ONU_REPO=
 ARCHIVE_ONLY=no
 
-while getopts 'fs:ABCNO:S' c; do
+while getopts 'fo:s:ABCNO:S' c; do
 	case "$c" in
 	A)
 		ARCHIVE_ONLY=yes
@@ -53,6 +54,12 @@ while getopts 'fs:ABCNO:S' c; do
 		;;
 	N)
 		NAME='helios-netdev'
+		NETDEV=yes
+		OPTE=yes
+		;;
+	o)
+		OPTE_VER="$OPTARG"
+		NAME="helios-netdev-$OPTE_VER"
 		NETDEV=yes
 		OPTE=yes
 		;;
@@ -118,7 +125,7 @@ for n in "${STEPS[@]}"; do
 		ARGS+=( '-F' 'omicron1' )
 	fi
 	if [[ $OPTE == yes ]]; then
-		ARGS+=( '-F' 'opte' )
+		ARGS+=( '-F' "opte=$OPTE_VER" )
 	fi
 	if [[ $SSH == yes ]]; then
 		ARGS+=( '-F' 'ssh' )

--- a/image/templates/helios/ramdisk-02-image.json
+++ b/image/templates/helios/ramdisk-02-image.json
@@ -112,7 +112,7 @@
 
         { "t": "pkg_install", "with": "opte", "pkgs": [
             "/driver/misc/tofino",
-            "/driver/network/opte"
+            "/driver/network/opte@${opte}"
         ] },
 
         { "t": "pkg_install", "with": "omicron1", "pkgs": [

--- a/image/ufs.sh
+++ b/image/ufs.sh
@@ -15,10 +15,17 @@ TARNAME='helios-dev'
 
 ARGS=()
 
-while getopts 'CNO' c; do
+while getopts 'o:CNO' c; do
 	case "$c" in
 	N)
 		EXTRA='-netdev'
+		TARNAME="helios$EXTRA"
+		ARGS+=( '-N' "$MACHINE$EXTRA-$CONSOLE-$VARIANT" )
+		ARGS+=( '-F' 'netdev' )
+		;;
+	o)
+		OPTE_VER="$OPTARG"
+		EXTRA="-netdev-$OPTE_VER"
 		TARNAME="helios$EXTRA"
 		ARGS+=( '-N' "$MACHINE$EXTRA-$CONSOLE-$VARIANT" )
 		ARGS+=( '-F' 'netdev' )


### PR DESCRIPTION
Lets you build an image with a specific opte version. e.g. installing an older version:
```console
$ pkg list -g https://pkg.oxide.computer/helios-netdev opte
NAME (PUBLISHER)                                  VERSION                    IFO
driver/network/opte (helios-netdev)               0.19.152                   ---

# Latest is 0.19.* but we want opte API version 18, so pass `-o 0.18` instead of `-N`

$ VARIANT=ramdisk ./strap.sh -f -o 0.18 -B
[...snip...]
Jan 09 16:26:28.987 INFO STEP 3: pkg_install, from: /home/luqman/helios-engvm/image/templates/helios/ramdisk-02-image.json                                                                                  
Jan 09 16:26:29.001 INFO exec: ["/usr/bin/pkg", "-R", "/rpool/images/work/helios/ramdisk-netdev", "install", "/driver/misc/tofino", "/driver/network/opte@0.18"]                                            
[...snip...]
skip global-only package = pkg://helios-netdev/driver/network/opte@0.18.145:20221111T210652Z
[...snip...]
+ ls -lh /rpool/images/output/helios-netdev-0.18-ramdisk.tar.gz
-rw-r--r--   1 root     root        176M Jan  9 16:29 /rpool/images/output/helios-netdev-0.18-ramdisk.tar.gz

$ MACHINE=builder ./ufs.sh -o 0.18
[...snip...]
+ ls -lh /rpool/images/output/helios-builder-netdev-0.18-ttya-ufs.ufs
-rw-r--r--   1 root     root        600M Jan  9 16:30 /rpool/images/output/helios-builder-netdev-0.18-ttya-ufs.ufs

$ ls -lh /rpool/images/output
total 1771545
-rw-r--r--   1 root     root        600M Jan  9 16:30 helios-builder-netdev-0.18-ttya-ufs.ufs
-rw-r--r--   1 root     root       2.15M Jan  9 16:28 helios-netdev-0.18-ramdisk-boot.tar.gz
-rw-r--r--   1 root     root        176M Jan  9 16:29 helios-netdev-0.18-ramdisk.tar.gz
```

Requires https://github.com/illumos/image-builder/pull/3