### PR TITLE
check for non empty authorized_keys file in image create

### DIFF
--- a/create.sh
+++ b/create.sh
@@ -115,8 +115,8 @@ mkdir "$TOP/tmp"
 # file available.
 #
 mkdir -p "$TOP/input/cpio"
-if [[ ! -f "$TOP/input/cpio/authorized_keys" ]]; then
-	if [[ ! -f $HOME/.ssh/authorized_keys ]]; then
+if [[ ! -s "$TOP/input/cpio/authorized_keys" ]]; then
+	if [[ ! -s $HOME/.ssh/authorized_keys ]]; then
 		echo "you have no $HOME/.ssh/authorized_keys file"
 		echo
 		echo "populate $TOP/input/cpio/authorized_keys and run again"


### PR DESCRIPTION
if you have an empty $HOME/.ssh/authorized_keys file, metadata-agent will not even create /root/.ssh/authorized_keys [^1][^2]

if /root/.ssh/authorized_keys is not present, firstboot.sh will fail when trying to copy it and not execute the rest of the script.

[^1]: https://github.com/illumos/metadata-agent/blob/oxide/src/provider/generic.rs#L92
[^2]: https://github.com/illumos/metadata-agent/blob/oxide/src/main.rs#L1315