### PR TITLE
Fix machine type on modern versions of QEMU

### DIFF
--- a/create.sh
+++ b/create.sh
@@ -215,7 +215,7 @@ cat > "$TOP/tmp/$VM.xml" <<EOF
   <currentMemory>$MEM</currentMemory>
   <vcpu>$VCPU</vcpu>
   <os>
-    <type arch="x86_64" machine="pc-i440fx-focal">hvm</type>
+    <type arch="x86_64" machine="pc">hvm</type>
     <boot dev="hd"/>
   </os>
   <features>


### PR DESCRIPTION
As mentioned in #22, "pc-i440fx-focal" is only valid for builds from Ubuntu-based builds of QEMU, not a supported type by mainline. Since "pc" already aliases to the modern equivalent of "pc-i440fx", we can use that instead for supporting other distributions.

**Note**: Until [this CR](https://code.illumos.org/c/illumos-gate/+/4747) against illumos is merged, the VM will boot but panic immediately. As a workaround, manually setting the smbios-address in the loader prompt will skip probing and allow the machine to boot on Arch:

```
Type '?' for a list of commands, 'help' for more detailed help.
ok set smbios-address=0x340800000
```